### PR TITLE
fix(repo): parse large semvers (>= 10.0.0) correctly

### DIFF
--- a/mod/octokit.ts
+++ b/mod/octokit.ts
@@ -248,7 +248,8 @@ export class GitHubClient {
         { owner, repo },
       );
       return release.tag_name;
-    } catch {
+    } catch (e) {
+      console.info(e);
       return null;
     }
   }

--- a/mod/repo.ts
+++ b/mod/repo.ts
@@ -8,7 +8,7 @@ export const regexp = (
   version = semverRegExp.source,
 ) =>
   RegExp(
-    "(^.*[^v]|^)(" + version + ")(.+@denopendabot\\s+)(" + repo + ")($|\\s.*$)",
+    "(" + version + ")(.+@denopendabot\\s+)(" + repo + ")($|\\s.*$)",
     "mg",
   );
 
@@ -17,7 +17,7 @@ export const versionRegExp = (
   version = semverRegExp.source,
 ) =>
   RegExp(
-    "(?<=^.*[^v]|^)" + version + "(?=.+@denopendabot\\s+" + repo +
+    "(" + version + ")(?=.+@denopendabot\\s+" + repo +
       "($|\\s.*$))",
     "mg",
   );
@@ -41,9 +41,9 @@ export async function getRepoUpdateSpecs(
   const specs: UpdateSpec[] = [];
 
   for (const match of matches) {
-    const name = match[7];
+    const name = match[6];
 
-    const initial = match[2];
+    const initial = match[1];
     const target = (release?.name === name)
       ? release.target
       : await ensuredGitHub.getLatestRelease(name);

--- a/mod/repo_test.ts
+++ b/mod/repo_test.ts
@@ -22,12 +22,12 @@ describe("regexp", () => {
     const m = Array.from(s.matchAll(regexp()));
 
     assert(m[0]);
-    assertEquals(m[0][2], "v1.26.0");
-    assertEquals(m[0][7], "denoland/deno");
+    assertEquals(m[0][1], "v1.26.0");
+    assertEquals(m[0][6], "denoland/deno");
 
     assert(m[1]);
-    assertEquals(m[1][2], "0.158.0");
-    assertEquals(m[1][7], "denoland/deno_std");
+    assertEquals(m[1][1], "0.158.0");
+    assertEquals(m[1][6], "denoland/deno_std");
   });
 
   it("plain text in markdown", () => {
@@ -38,12 +38,12 @@ describe("regexp", () => {
     const m = Array.from(s.matchAll(regexp()));
 
     assert(m[0]);
-    assertEquals(m[0][2], "v1.26.0");
-    assertEquals(m[0][7], "denoland/deno");
+    assertEquals(m[0][1], "v1.26.0");
+    assertEquals(m[0][6], "denoland/deno");
 
     assert(m[1]);
-    assertEquals(m[1][2], "0.158.0");
-    assertEquals(m[1][7], "denoland/deno_std");
+    assertEquals(m[1][1], "0.158.0");
+    assertEquals(m[1][6], "denoland/deno_std");
   });
 
   it("badges in markdown", () => {
@@ -54,12 +54,12 @@ describe("regexp", () => {
     const m = Array.from(s.matchAll(regexp()));
 
     assert(m[0]);
-    assertEquals(m[0][2], "v1.26.0");
-    assertEquals(m[0][7], "denoland/deno");
+    assertEquals(m[0][1], "v1.26.0");
+    assertEquals(m[0][6], "denoland/deno");
 
     assert(m[1]);
-    assertEquals(m[1][2], "0.158.0");
-    assertEquals(m[1][7], "denoland/deno_std");
+    assertEquals(m[1][1], "0.158.0");
+    assertEquals(m[1][6], "denoland/deno_std");
   });
 
   it("GitHub Action", () => {
@@ -70,8 +70,8 @@ describe("regexp", () => {
     `;
     const m = Array.from(s.matchAll(regexp()));
     assert(m[0]);
-    assertEquals(m[0][2], "v1.26.0");
-    assertEquals(m[0][7], "denoland/deno");
+    assertEquals(m[0][1], "v1.26.0");
+    assertEquals(m[0][6], "denoland/deno");
   });
 });
 
@@ -124,6 +124,17 @@ describe("getUpdateSpecs", () => {
 
     assertEquals(specs[0].name, "cloudflare/wrangler2");
     assertEquals(specs[0].initial, "2.1.6");
+  });
+
+  it("nodejs/node", async () => {
+    const s = "v16.7.0 <!-- @denopendabot nodejs/node";
+    const specs = await getRepoUpdateSpecs(s);
+    console.log(specs);
+
+    assertEquals(specs.length, 1);
+
+    assertEquals(specs[0].name, "nodejs/node");
+    assertEquals(specs[0].initial, "v16.7.0");
   });
 });
 


### PR DESCRIPTION
- refactor(octokit): log when no release found
- fix(repo): parse semvers with major number > 9 correctly
