### PR TITLE
fix: changed to do a force-push if a PR already been created.

### DIFF
--- a/app/webhooks.ts
+++ b/app/webhooks.ts
@@ -121,10 +121,12 @@ const createWorkflow = async (
   const message = "ci: setup Denopendabot";
   const content = await Deno.readTextFile("./app/denopendabot.yml");
 
-  await github.createCommit(head, message, [{
+  const headBranch = await github.createBranch(head);
+  const commit = await github.createCommit(headBranch.commit.sha, message, [{
     path: ".github/workflows/denopendabot.yml",
     content: () => content,
   }]);
+  await github.updateBranch(head, commit.sha);
 
   await github.createPullRequest({
     base,

--- a/integration/app_test.ts
+++ b/integration/app_test.ts
@@ -36,6 +36,8 @@ Deno.test("installation", async () => {
 
   // ensure the base branch
   await github.createBranch("test-install");
+  const latest = await github.getLatestCommit();
+  await github.updateBranch("test-install", latest.sha);
 
   const started_at = new Date();
 


### PR DESCRIPTION
Fix #1673 

Fixed this by creating a commit tree first and then updating HEAD on the working branch.

Changed `createBranch`, `createCommit` functions and added `getTreeWithSha` function.
I also fixed the test file, but it may be imcomplete.

You can check the following link to see the force-pushed PR.
https://github.com/kamekyame/denopendabot-test/pull/1

**Concerm**
I really don't want to force-push if there are no files to change, but the GitHub API does not allow us to compare between both commits.
We can compare by creating temp branch but it's not smart. What do you think?