### PR TITLE
refactor: migrate from esm.sh to npm:

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Cache dependencies
         run: deno cache mod/*.ts ${{ env.CI_MAIN && 'integration/octokit_test.ts' || '' }}
 
+      - name: Type check
+        run: deno task check
+
       - name: Run tests
         run: >
           deno task test --coverage=./coverage mod/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ by comments of `@denopendabot {owner}/{repo}`.
 - Commits are created for each updated module/repository individually
 - Each run of Denopendabot creates only one pull request
 
-See [example pull requests](https://github.com/hasundue/denopendabot/pulls?q=is%3Apr+is%3Amerged+label%3Atest).
+See
+[example pull requests](https://github.com/hasundue/denopendabot/pulls?q=is%3Apr+is%3Amerged+label%3Atest).
 
 ## :rocket: Getting started
 

--- a/app.ts
+++ b/app.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.205.0/http/server.ts";
-import { Hono } from "https://deno.land/x/hono@v3.9.2/mod.ts";
+import { Hono } from "https://deno.land/x/hono@v3.10.0-rc.1/mod.ts";
 import { getDeployEnvUrl, getThisDeployEnv } from "./app/deployments.ts";
 import { handler } from "./app/webhooks.ts";
 

--- a/app/webhooks.ts
+++ b/app/webhooks.ts
@@ -3,7 +3,7 @@ import { intersect } from "https://deno.land/std@0.205.0/collections/intersect.t
 import { Octokit } from "npm:@octokit/core@5.0.1";
 import { App } from "npm:@octokit/app@14.0.1";
 import { EmitterWebhookEventName } from "npm:@octokit/webhooks@12.0.3";
-import { HonoRequest } from "https://deno.land/x/hono@v3.9.2/mod.ts";
+import { HonoRequest } from "https://deno.land/x/hono@v3.10.0-rc.1/mod.ts";
 import { env } from "./env.ts";
 import { DeployEnv, getThisDeployEnv } from "./deployments.ts";
 import * as mod from "../mod.ts";

--- a/app/webhooks.ts
+++ b/app/webhooks.ts
@@ -1,6 +1,6 @@
 import { retry } from "https://deno.land/std@0.205.0/async/mod.ts";
 import { intersect } from "https://deno.land/std@0.205.0/collections/intersect.ts";
-import { Octokit } from "npm:@octokit/core@4.1.0";
+import { Octokit } from "npm:@octokit/core@5.0.1";
 import { App } from "npm:@octokit/app@14.0.1";
 import { EmitterWebhookEventName } from "npm:@octokit/webhooks@12.0.3";
 import { HonoRequest } from "https://deno.land/x/hono@v3.9.2/mod.ts";

--- a/app/webhooks.ts
+++ b/app/webhooks.ts
@@ -1,8 +1,8 @@
 import { retry } from "https://deno.land/std@0.205.0/async/mod.ts";
 import { intersect } from "https://deno.land/std@0.205.0/collections/intersect.ts";
-import { Octokit } from "https://esm.sh/@octokit/core@4.1.0#~";
-import { App } from "https://esm.sh/@octokit/app@13.1.2#=";
-import { EmitterWebhookEventName } from "https://esm.sh/@octokit/webhooks@12.0.3";
+import { Octokit } from "npm:@octokit/core@4.1.0";
+import { App } from "npm:@octokit/app@14.0.1";
+import { EmitterWebhookEventName } from "npm:@octokit/webhooks@12.0.3";
 import { HonoRequest } from "https://deno.land/x/hono@v3.9.2/mod.ts";
 import { env } from "./env.ts";
 import { DeployEnv, getThisDeployEnv } from "./deployments.ts";
@@ -275,9 +275,9 @@ app.webhooks.on("check_suite.completed", async ({ name, octokit, payload }) => {
 
 export const handler = async (request: HonoRequest<"/api/github/webhooks">) => {
   await app.webhooks.verifyAndReceive({
-    id: request.headers.get("x-github-delivery")!,
-    signature: (request.headers.get("x-hub-signature-256")!),
+    id: request.header("x-github-delivery")!,
+    name: request.header("x-github-event") as EmitterWebhookEventName,
     payload: await request.text(),
-    name: request.headers.get("x-github-event") as EmitterWebhookEventName,
+    signature: (request.header("x-hub-signature-256")!),
   });
 };

--- a/cli.ts
+++ b/cli.ts
@@ -1,4 +1,4 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.7/mod.ts";
+import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/mod.ts";
 import { env } from "./mod/env.ts";
 import {
   createCommits,

--- a/cli.ts
+++ b/cli.ts
@@ -1,4 +1,4 @@
-import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/mod.ts";
+import { Command } from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
 import { env } from "./mod/env.ts";
 import {
   createCommits,

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "tasks": {
     "run": "deno run --allow-env --allow-net --allow-read cli.ts",
     "run:app": "deno run --allow-env --allow-net --allow-read app.ts",
+    "check": "deno test --no-run",
     "test": "deno test --allow-env --allow-net --allow-read --no-check",
     "dev": "deno fmt && deno lint && deno task test -q mod/ app/ --fail-fast"
   }

--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,12 @@
 {
   "tasks": {
+    "cache": "deno cache ./**/*.ts",
     "run": "deno run --allow-env --allow-net --allow-read cli.ts",
     "run:app": "deno run --allow-env --allow-net --allow-read app.ts",
     "check": "deno test --no-run",
     "test": "deno test --allow-env --allow-net --allow-read --no-check",
-    "dev": "deno fmt && deno lint && deno task test -q mod/ app/ --fail-fast"
+    "dev": "deno fmt && deno lint && deno task test -q mod/ app/ --fail-fast",
+    "update": "deno run -A https://deno.land/x/molt@0.11.0/cli.ts ./**/*.ts",
+    "update:commit": "deno task -q update --commit --prefix 'build(deps):' --pre-commit=fmt"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "cache": "deno cache ./**/*.ts",
     "run": "deno run --allow-env --allow-net --allow-read cli.ts",
     "run:app": "deno run --allow-env --allow-net --allow-read app.ts",
-    "check": "deno test --no-run",
+    "check": "deno check ./**/*.ts",
     "test": "deno test --allow-env --allow-net --allow-read --no-check",
     "dev": "deno fmt && deno lint && deno task test -q mod/ app/ --fail-fast",
     "update": "deno run -A https://deno.land/x/molt@0.11.0/cli.ts ./**/*.ts",

--- a/integration/app_test.ts
+++ b/integration/app_test.ts
@@ -1,6 +1,6 @@
 import { assert } from "https://deno.land/std@0.205.0/testing/asserts.ts";
 import { retry } from "https://deno.land/std@0.205.0/async/mod.ts";
-import { Octokit } from "https://esm.sh/@octokit/core@4.1.0#~";
+import { Octokit } from "npm:@octokit/core@5.0.1";
 import { env } from "../app/env.ts";
 import { GitHubClient } from "../mod/octokit.ts";
 

--- a/integration/src/deps.ts
+++ b/integration/src/deps.ts
@@ -1,3 +1,3 @@
 // deno-lint-ignore-file
 
-import $ from "https://deno.land/x/dax@0.30.0/mod.ts";
+import $ from "https://deno.land/x/dax@0.35.0/mod.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -2,7 +2,7 @@ import { groupBy } from "https://deno.land/std@0.205.0/collections/group_by.ts";
 import { intersect } from "https://deno.land/std@0.205.0/collections/intersect.ts";
 import { globToRegExp } from "https://deno.land/std@0.205.0/path/glob.ts";
 import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
-import { Octokit } from "https://esm.sh/@octokit/core@4.1.0#~";
+import { Octokit } from "npm:@octokit/core@5.0.1";
 import { env } from "./mod/env.ts";
 import {
   CommitType,

--- a/mod/octokit.ts
+++ b/mod/octokit.ts
@@ -1,7 +1,7 @@
 import { retry } from "https://deno.land/std@0.205.0/async/mod.ts";
 import { groupBy } from "https://deno.land/std@0.205.0/collections/group_by.ts";
 import { decode } from "https://deno.land/std@0.205.0/encoding/base64.ts";
-import { Octokit } from "https://esm.sh/@octokit/core@4.1.0#~";
+import { Octokit } from "npm:@octokit/core@5.0.1";
 import { Update } from "./common.ts";
 
 type UpdateContent = Pick<Update, "path" | "content">;


### PR DESCRIPTION
- build: add `check` task
- ci(test): add `check` step
- bump @octokit/app from 13.1.2 to 14.0.1
- bump @octokit/core from 4.1.0 to 5.0.1
- bump deno.land/x/cliffy from v0.25.7 to v1.0.0-rc.3
- bump deno.land/x/dax from 0.30.0 to 0.35.0
- bump deno.land/x/hono from v3.9.2 to v3.10.0-rc.1
- build: add tasks in deno.json
- docs(readme): fix the link for example PRs
- chore(build): fix `check` task
- build(deps): update import for cliffy
